### PR TITLE
Build the sdk during provisioning

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -25,11 +25,10 @@ fi
 #colorize the bash prompt - it's easier to tell if you are in the vm or not
 echo "PS1='\[\e[1;32m\][\u@\h \W]\$\[\e[0m\] '" >> /home/vagrant/.bashrc
 
-#Prompt the user to install the SDK
-if ! [ -d /home/vagrant/esp-open-sdk ]; then
-    echo "---------------------------------------------------------------"
-    echo "\033[32mNOTE: You still need to install the esp-open-sdk\033[0m"
-    echo "To Install the esp-open-sdk:"
-    echo "  esp-open-sdk install"
-    echo ""
-fi
+# Install the sdk as the vagrant user
+sudo -u vagrant -i esp-open-sdk install
+
+# Add the sdk to the path
+echo export PATH=/home/vagrant/esp-open-sdk/xtensa-lx106-elf/bin:\$PATH >> /home/vagrant/.profile
+echo export XTENSA_TOOLS_ROOT=/home/vagrant/esp-open-sdk/xtensa-lx106-elf/bin >> /home/vagrant/.profile
+echo export SDK_BASE=/home/vagrant/esp-open-sdk/sdk >> /home/vagrant/.profile


### PR DESCRIPTION
This solves #1 by building the SDK as the vagrant user during provisioning and then adding the requisite env vars to `/home/vagrant/.profile`.  The spinner does make a mess in the logs though.  I think it's part of the crosstool-NG build process - hopefully there's a way of disabling it.